### PR TITLE
Add setting to enable playing music when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Platforms included:
 - `screenshot`
 - `wheel`
 - `video`
+- `music`
 
 ---
 

--- a/components/GamesList.qml
+++ b/components/GamesList.qml
@@ -365,6 +365,7 @@ FocusScope {
 		}
 	}
 
+	property string musicSource: currentGame.assets.music
 	Component {
 		id: videoPreviewWrapper
 
@@ -383,7 +384,16 @@ FocusScope {
 			loops: MediaPlayer.Infinite
 			autoPlay: true
 			visible: videoSource
-			muted: videosound
+			muted: (musicSource && musicsound) || videosound
+
+			Audio {
+				id: musicPlayer
+
+				autoPlay: true
+				muted: !musicsound
+				loops: MediaPlayer.Infinite
+				source: musicSource
+			}
 		}
 	}
 

--- a/components/GamesWheel.qml
+++ b/components/GamesWheel.qml
@@ -400,6 +400,8 @@ FocusScope {
 		}
 	}
 
+	property string musicSource: currentGame.assets.music
+
 	Component {
 		id: videoPreviewWrapper
 
@@ -411,8 +413,17 @@ FocusScope {
 			loops: MediaPlayer.Infinite
 			autoPlay: true
 			visible: videoSource && videoplaygames
-			muted: videosound
+			muted: (musicSource && musicsound) || videosound
+			Audio {
+				id: musicPlayer
+
+				autoPlay: true
+				muted: !musicsound
+				loops: MediaPlayer.Infinite
+				source: musicSource
+			}
 		}
+
 	}
 	
 	Item {

--- a/components/Settings.qml
+++ b/components/Settings.qml
@@ -38,6 +38,7 @@ FocusScope {
 			[ "Play Videos on Collections View",  "videoplaycollections",  "",  "Enabled,Disabled" ],
 			[ "Play Videos on Games View",  "videoplaygames",  "",  "Enabled,Disabled" ],
 			[ "Play Video Sounds",  "videosound",  "",  "Enabled,Disabled" ],
+			[ "Play Music instead of video when available",  "musicsound",  "",  "Enabled,Disabled" ],
 			[ "Show All Games Playlist", "allGamesCollection", "", "Yes,No" ],
 			[ "Show Favorites Playlist", "favoritesCollection", "", "Yes,No" ],
 			[ "Show Last Played Playlist", "lastPlayedCollection", "", "Yes,No" ],

--- a/theme.qml
+++ b/theme.qml
@@ -155,6 +155,10 @@ FocusScope {
 		}
 	}
 
+        property bool musicsound: {
+            return api.memory.get('musicsound') == "Enabled";
+        }
+
 	property int allGamesCollection: api.memory.get('allGamesCollectionIndex') || 0
     property int favoritesCollection: api.memory.get('favoritesCollectionIndex') || 0
     property int lastPlayedCollection: api.memory.get('lastPlayedCollectionIndex') || 0


### PR DESCRIPTION
This patch adds the ability to play music from a game's assets, when available.
When enabled this will mute the video audio and only play the music.